### PR TITLE
Fixed crash with empty constructors.

### DIFF
--- a/AutoDI.Fody/ModuleWeaver - Copy.InjectContainer.cs
+++ b/AutoDI.Fody/ModuleWeaver - Copy.InjectContainer.cs
@@ -1,5 +1,0 @@
-﻿// ReSharper disable once CheckNamespace
-partial class ModuleWeaver
-{
-    
-}

--- a/AutoDI.Fody/ModuleWeaver.Container.cs
+++ b/AutoDI.Fody/ModuleWeaver.Container.cs
@@ -58,11 +58,6 @@ partial class ModuleWeaver
         resolveMethod.Parameters.Add(new ParameterDefinition("parameters", ParameterAttributes.None, ModuleDefinition.Get<object[]>()));
         resolveMethod.ReturnType = ModuleDefinition.Get<object>();
         
-        TypeReference paramsAttribute = ModuleDefinition.Get<ParamArrayAttribute>();
-        MethodReference paramsArrayCtor =
-            ModuleDefinition.ImportReference(paramsAttribute.Resolve().GetConstructors().Single());
-        resolveMethod.CustomAttributes.Add(new CustomAttribute(paramsArrayCtor));
-
         var body = resolveMethod.Body.GetILProcessor();
         body.Emit(OpCodes.Ldsfld, mapField);
 

--- a/AutoDI.Fody/ModuleWeaver.Mapping.cs
+++ b/AutoDI.Fody/ModuleWeaver.Mapping.cs
@@ -1,11 +1,9 @@
 ﻿// ReSharper disable once CheckNamespace
 
-using System.Collections.Generic;
-using System.Linq;
-using AutoDI;
 using AutoDI.Fody;
 using Mono.Cecil;
-using Mono.Cecil.Rocks;
+using System.Collections.Generic;
+using System.Linq;
 
 partial class ModuleWeaver
 {

--- a/AutoDI.Fody/ModuleWeaver.cs
+++ b/AutoDI.Fody/ModuleWeaver.cs
@@ -246,6 +246,7 @@ public partial class ModuleWeaver
 
             injector.Insert(end);
 
+            constructor.Body.OptimizeMacros();
 
             void ResolveDependency(TypeReference dependencyType, ICustomAttributeProvider source, 
                 IEnumerable<Instruction> loadSource, 
@@ -305,9 +306,6 @@ public partial class ModuleWeaver
                 injector.Insert(afterParam);
             }
         }
-
-        constructor.Body.OptimizeMacros();
-
     }
 
     private void InsertObjectConstant(Injector injector, object constant, TypeDefinition type)

--- a/NuGet/AutoDI.Fody/AutoDI.Fody.nuspec
+++ b/NuGet/AutoDI.Fody/AutoDI.Fody.nuspec
@@ -15,8 +15,8 @@
     <copyright>Copyright 2017</copyright>
     <tags>AutoDI, Fody</tags>
     <dependencies>
-      <dependency id="Fody" version="2.1.0" />
-      <dependency id="AutoDI" version ="[2.1.2,2.2.0)"/>
+      <dependency id="Fody" version="2.1.*" />
+      <dependency id="AutoDI" version ="[2.1.3,2.2.0)"/>
     </dependencies>
   </metadata>
 </package>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 # configuration for master/CI branch
 -
   environment:
-    autodi_version: 2.1.2
+    autodi_version: 2.1.3
   branches:
     only:
     - master
@@ -39,7 +39,7 @@
 #Configuration for releases
 -
   environment:
-    autodi_version: 2.1.2
+    autodi_version: 2.1.3
   branches:
     only:
     - release


### PR DESCRIPTION
Fixed crash on .net core projects.
Version bump to 2.1.3