### PR TITLE
Delay singleton creation.

### DIFF
--- a/AutoDI.AssemblyGenerator/AssemblyMixins.cs
+++ b/AutoDI.AssemblyGenerator/AssemblyMixins.cs
@@ -7,12 +7,13 @@ namespace AutoDI.AssemblyGenerator
 {
     public static class AssemblyMixins
     {
-        public static object GetStaticProperty<TContainingType>(this Assembly assembly, string propertyName) where TContainingType : class
+        public static object GetStaticProperty<TContainingType>(this Assembly assembly, string propertyName, Type containerType = null) where TContainingType : class
         {
             if (assembly == null) throw new ArgumentNullException(nameof(assembly));
             if (propertyName == null) throw new ArgumentNullException(nameof(propertyName));
 
-            Type type = assembly.GetType(typeof(TContainingType).FullName);
+            string typeName = TypeMixins.GetTypeName(typeof(TContainingType), containerType);
+            Type type = assembly.GetType(typeName);
             if (type == null)
                 throw new AssemblyGetPropertyException($"Could not find '{typeof(TContainingType).FullName}' in '{assembly.FullName}'");
 

--- a/AutoDI.Fody.Tests/ManualMappingTests.cs
+++ b/AutoDI.Fody.Tests/ManualMappingTests.cs
@@ -23,8 +23,8 @@ namespace AutoDI.Fody.Tests
             {
                 if (args.Weaver.Name == "AutoDI")
                 {
-                    dynamic containerWeaver = args.Weaver;
-                    containerWeaver.Config = XElement.Parse($@"
+                    dynamic weaver = args.Weaver;
+                    weaver.Config = XElement.Parse($@"
     <AutoDI Behavior=""{Behaviors.None}"">
         <map from=""(.*)\.I(.+)"" to=""$1.$2"" />
         <map from="".*"" to=""$0"" />

--- a/AutoDI.Fody.Tests/SingletonTests.cs
+++ b/AutoDI.Fody.Tests/SingletonTests.cs
@@ -1,0 +1,126 @@
+﻿using AutoDI.AssemblyGenerator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Reflection;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace AutoDI.Fody.Tests
+{
+    [TestClass]
+    public class SingletonTests
+    {
+        private static Assembly _singleton;
+        private static Assembly _inSetup;
+
+        [ClassInitialize]
+        public static async Task Initialize(TestContext context)
+        {
+            var gen = new Generator();
+
+            gen.WeaverAdded += (sender, args) =>
+            {
+                var xml = XElement.Parse(@"
+                    <AutoDI>
+                        <type name="".*"" lifetime=""Singleton"" />
+                    </AutoDI>");
+                dynamic weaver = args.Weaver;
+                weaver.Config = xml;
+            };
+
+            var testAssemblies = await gen.Execute();
+            _singleton = testAssemblies["singleton"].Assembly;
+            _inSetup = testAssemblies["inSetup"].Assembly;
+        }
+
+        [TestMethod]
+        [Description("Issue 55")]
+        public void SingletonNotCreatedUntilAfterSetupMethod()
+        {
+            bool isCreated = (bool)_singleton.GetStaticProperty<SingletonResolutionTest.Service>(nameof(SingletonResolutionTest.Service
+                .IsCreated), GetType());
+            Assert.IsFalse(isCreated);
+
+            AutoDIContainer.Inject(_singleton);
+
+            isCreated = (bool)_singleton.GetStaticProperty<SingletonResolutionTest.Service>(nameof(SingletonResolutionTest.Service
+                .IsCreated), GetType());
+            Assert.IsTrue(isCreated);
+        }
+
+        [TestMethod]
+        [Description("Issue 55")]
+        public void CanResolveGeneratedSingletonInsideOfSetupMethod()
+        {
+            bool isCreated = (bool)_inSetup.GetStaticProperty<SingletonResolvedInSetupMethod.Service>(nameof(SingletonResolvedInSetupMethod.Service
+                .IsCreated), GetType());
+            Assert.IsFalse(isCreated);
+
+            AutoDIContainer.Inject(_inSetup);
+        }
+    }
+
+    //<assembly:singleton />
+    //<ref: AutoDI/>
+    //<weaver: AutoDI />
+    namespace SingletonResolutionTest
+    {
+        using AutoDI;
+        using System;
+
+        public interface IService { }
+
+        public class Service : IService
+        {
+            public static bool IsCreated { get; set; }
+
+            public Service()
+            {
+                IsCreated = true;
+            }
+        }
+
+        public static class Foo
+        {
+            [SetupMethod]
+            public static void Setup(ContainerMap map)
+            {
+                if (Service.IsCreated) throw new Exception();
+            }
+        }
+    }
+    //</assembly>
+
+    //<assembly:inSetup />
+    //<ref: AutoDI/>
+    //<weaver: AutoDI />
+    namespace SingletonResolvedInSetupMethod
+    {
+        using AutoDI;
+        using System;
+
+        public interface IService { }
+
+        public class Service : IService
+        {
+            public static bool IsCreated { get; set; }
+
+            public Service()
+            {
+                IsCreated = true;
+            }
+        }
+
+        public static class Foo
+        {
+            [SetupMethod]
+            public static void Setup(ContainerMap map)
+            {
+                if (Service.IsCreated) throw new Exception();
+                var service = map.Get<IService>();
+                if (!(service is Service)) throw new Exception();
+                if (!Service.IsCreated) throw new Exception();
+            }
+        }
+    }
+    //</assembly>
+}

--- a/AutoDI/ContainerMapMixins.cs
+++ b/AutoDI/ContainerMapMixins.cs
@@ -4,10 +4,16 @@ namespace AutoDI
 {
     public static class ContainerMapMixins
     {
+        public static void AddSingleton<T>(this ContainerMap map, T instance, Type[] keys)
+        {
+            if (map == null) throw new ArgumentNullException(nameof(map));
+            map.AddSingleton(() => instance, keys);
+        }
+
         public static void AddSingleton<TService, TImplementation>(this ContainerMap map, TImplementation instance)
         {
             if (map == null) throw new ArgumentNullException(nameof(map));
-            map.AddSingleton(instance, new[] { typeof(TService) });
+            map.AddSingleton(() => instance, new[] { typeof(TService) });
         }
 
         public static void AddSingleton<TService, TImplementation>(this ContainerMap map)
@@ -18,7 +24,7 @@ namespace AutoDI
         public static void AddSingleton<TService>(this ContainerMap map)
         {
             if (map == null) throw new ArgumentNullException(nameof(map));
-            map.AddSingleton(Activator.CreateInstance<TService>(), new[] { typeof(TService) });
+            map.AddSingleton(Activator.CreateInstance<TService>, new[] { typeof(TService) });
         }
 
         public static void AddLazySingleton<TService, TImplementation>(this ContainerMap map, Func<TImplementation> factory)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 # configuration for master/CI branch
 -
   environment:
-    autodi_version: 2.1.3
+    autodi_version: 2.1.4
   branches:
     only:
     - master
@@ -39,7 +39,7 @@
 #Configuration for releases
 -
   environment:
-    autodi_version: 2.1.3
+    autodi_version: 2.1.4
   branches:
     only:
     - release


### PR DESCRIPTION
Delay the creation of singletons until after the setup method is called. This allows for run-time dependencies to be injected.

Fixes #55 