### PR TITLE
Updated Mono.Cecil to 0.11.0

### DIFF
--- a/AutoDI.AssemblyGenerator/AutoDI.AssemblyGenerator.csproj
+++ b/AutoDI.AssemblyGenerator/AutoDI.AssemblyGenerator.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.10.4" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.10.0" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.2.1" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net472'">

--- a/AutoDI.Build.Tests/AutoDI.Build.Tests.csproj
+++ b/AutoDI.Build.Tests/AutoDI.Build.Tests.csproj
@@ -7,10 +7,10 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="Mono.Cecil" Version="0.10.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AutoDI.Build/AutoDI.Build.csproj
+++ b/AutoDI.Build/AutoDI.Build.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.10.4" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.0" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net472'">

--- a/AutoDI.Generator/AutoDI.Generator.csproj
+++ b/AutoDI.Generator/AutoDI.Generator.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.10.4" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.0" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net472'">

--- a/AutoDI.Tests/AutoDI.Tests.csproj
+++ b/AutoDI.Tests/AutoDI.Tests.csproj
@@ -6,11 +6,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-    <PackageReference Include="Moq" Version="4.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Moq" Version="4.13.0" />
     <PackageReference Include="Moq.AutoMock" Version="1.2.0.120" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixed issue with portable PDB format not being written correctly.
Fixes #157