### PR TITLE
Add ability to inject into module initializer

### DIFF
--- a/AutoDI.AspNetCore/WebHostBuilderMixins.cs
+++ b/AutoDI.AspNetCore/WebHostBuilderMixins.cs
@@ -1,6 +1,6 @@
 ﻿using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
-[assembly:AutoDI.Settings(AutoInit = false)]
+[assembly:AutoDI.Settings(InitMode = AutoDI.InitMode.None)]
 namespace AutoDI.AspNetCore
 {
     public static class WebHostBuilderMixins

--- a/AutoDI.Build.Tests/ManualInjectionOfContainer.cs
+++ b/AutoDI.Build.Tests/ManualInjectionOfContainer.cs
@@ -48,7 +48,7 @@ namespace AutoDI.Build.Tests
 //<type:ConsoleApplication/>
 //<ref: AutoDI />
 //<weaver: AutoDI.Build.ProcessAssemblyTask />
-//<raw:[assembly:AutoDI.Settings(AutoInit = false)] />
+//<raw:[assembly:AutoDI.Settings(InitMode = AutoDI.InitMode.None)] />
 namespace ManualInjectionNamespace
 {
     using AutoDI;

--- a/AutoDI.Build.Tests/ModuleLoadInjectionTests.cs
+++ b/AutoDI.Build.Tests/ModuleLoadInjectionTests.cs
@@ -1,0 +1,80 @@
+﻿using AutoDI.AssemblyGenerator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModuleLoadInjectionNamespace;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace AutoDI.Build.Tests
+{
+    [TestClass]
+    public class ModuleLoadInjectionTests
+    {
+        private static Assembly _testAssembly;
+
+        [ClassInitialize]
+        public static async Task Initialize(TestContext context)
+        {
+            var gen = new Generator();
+
+            _testAssembly = (await gen.Execute()).SingleAssembly();
+        }
+
+        [ClassCleanup]
+        public static void Cleanup()
+        {
+            DI.Dispose(_testAssembly);
+        }
+
+        [TestMethod]
+        public void InitThrowsIfModuleLoadAssembly()
+        {
+            try
+            {
+                DI.Init(_testAssembly);
+            }
+            catch (TargetInvocationException e)
+                when (e.InnerException is AlreadyInitializedException)
+            {
+                return;
+            }
+            Assert.Fail($"Excepted {nameof(AlreadyInitializedException)}");
+        }
+
+        [TestMethod]
+        public void TryInitReturnsFalseOnFirstInvocation()
+        {
+            Assert.IsFalse(DI.TryInit(_testAssembly));
+        }
+
+        [TestMethod]
+        public void LibraryDependenciesAreInjected()
+        {
+            dynamic sut = _testAssembly.CreateInstance<ModuleLoadingLibrary>();
+            Assert.IsTrue(((object)sut.Service).Is<Service>());
+        }
+    }
+}
+
+//<assembly />
+//<ref: AutoDI />
+//<weaver: AutoDI.Build.ProcessAssemblyTask />
+//<raw:[assembly:AutoDI.Settings(InitMode = AutoDI.InitMode.ModuleLoad)] />
+namespace ModuleLoadInjectionNamespace
+{
+    using AutoDI;
+
+    public class ModuleLoadingLibrary
+    {
+        public IService Service { get; }
+
+        public ModuleLoadingLibrary([Dependency] IService service = null)
+        {
+            Service = service;
+        }
+    }
+
+    public interface IService { }
+
+    public class Service : IService { }
+}
+//</assembly>

--- a/AutoDI.Build.Tests/SettingsTests.cs
+++ b/AutoDI.Build.Tests/SettingsTests.cs
@@ -20,5 +20,13 @@ namespace AutoDI.Build.Tests
 
             Assert.AreEqual((int)CodeLanguage.None, (int)settings.DebugCodeGeneration);
         }
+
+        [TestMethod]
+        public void InitModeDefaultsEntryPoint()
+        {
+            var settings = new Settings();
+
+            Assert.AreEqual((int)InitMode.EntryPoint, (int)settings.InitMode);
+        }
     }
 }

--- a/AutoDI.Build/AutoDI.Build.csproj
+++ b/AutoDI.Build/AutoDI.Build.csproj
@@ -28,6 +28,7 @@
     <Compile Include="..\AutoDI\Constants.cs" Link="Constants.cs" />
     <Compile Include="..\AutoDI\DebugLogLevel.cs" Link="DebugLogLevel.cs" />
     <Compile Include="..\AutoDI\IncludeAssemblyAttribute.cs" Link="IncludeAssemblyAttribute.cs" />
+    <Compile Include="..\AutoDI\InitMode.cs" Link="InitMode.cs" />
     <Compile Include="..\AutoDI\Lifetime.cs" Link="Lifetime.cs" />
     <Compile Include="..\AutoDI\MapAttribute.cs" Link="MapAttribute.cs" />
     <Compile Include="..\AutoDI\SettingsAttribute.cs" Link="SettingsAttribute.cs" />

--- a/AutoDI.Build/ProcessAssemblyTask.InjectContainer.cs
+++ b/AutoDI.Build/ProcessAssemblyTask.InjectContainer.cs
@@ -1,4 +1,5 @@
-﻿using Mono.Cecil;
+﻿using System.Linq;
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 
 namespace AutoDI.Build
@@ -19,6 +20,48 @@ namespace AutoDI.Build
             {
                 Logger.Debug($"No entry point in {ModuleDefinition.FileName}. Skipping container injection.", DebugLogLevel.Default);
             }
+        }
+
+        private void InjectModuleCtorInitCall(MethodReference initMethod)
+        {
+            var moduleClass = ModuleDefinition.Types.FirstOrDefault(t => t.Name == "<Module>");
+            if (moduleClass == null)
+            {
+                Logger.Debug($"No module class in {ModuleDefinition.FileName}. Skipping container injection.", DebugLogLevel.Default);
+                return;
+            }
+
+            var cctor = FindOrCreateCctor(moduleClass);    
+            if (cctor != null)
+            {
+                Logger.Debug("Injecting AutoDI .cctor init call", DebugLogLevel.Verbose);
+
+                var injector = new Injector(cctor);
+                injector.Insert(OpCodes.Ldnull);
+                injector.Insert(OpCodes.Call, initMethod);
+            }
+            else
+            {
+                Logger.Debug($"Couldn't find or create .cctor in {ModuleDefinition.FileName}. Skipping container injection.", DebugLogLevel.Default);
+            }
+
+        }
+
+        private MethodDefinition FindOrCreateCctor(TypeDefinition moduleClass)
+        {
+            var cctor = moduleClass.Methods.FirstOrDefault(m => m.Name == ".cctor");
+            if (cctor == null)
+            {
+                var attributes = MethodAttributes.Private
+                    | MethodAttributes.HideBySig
+                    | MethodAttributes.Static
+                    | MethodAttributes.SpecialName
+                    | MethodAttributes.RTSpecialName;
+                cctor = new MethodDefinition(".cctor", attributes, ModuleDefinition.ImportReference(typeof(void)));
+                moduleClass.Methods.Add(cctor);
+                cctor.Body.Instructions.Add(Instruction.Create(OpCodes.Ret));
+            }
+            return cctor;
         }
     }
 }

--- a/AutoDI.Build/ProcessAssemblyTask.InjectContainer.cs
+++ b/AutoDI.Build/ProcessAssemblyTask.InjectContainer.cs
@@ -22,7 +22,7 @@ namespace AutoDI.Build
             }
         }
 
-        private void InjectModuleCtorInitCall(MethodReference initMethod)
+        private void InjectModuleCctorInitCall(MethodReference initMethod)
         {
             var moduleClass = ModuleDefinition.Types.FirstOrDefault(t => t.Name == "<Module>");
             if (moduleClass == null)

--- a/AutoDI.Build/ProcessAssemblyTask.cs
+++ b/AutoDI.Build/ProcessAssemblyTask.cs
@@ -60,7 +60,12 @@ namespace AutoDI.Build
 
                     ModuleDefinition.Types.Add(GenerateAutoDIClass(mapping, settings, gen, out MethodDefinition initMethod));
 
-                    if (settings.AutoInit)
+                    // AutoLibraryInit overrides AutoInit setting
+                    if (settings.AutoLibraryInit)
+                    {
+                        InjectModuleCtorInitCall(initMethod);
+                    }
+                    else if (settings.AutoInit)
                     {
                         InjectInitCall(initMethod);
                     }

--- a/AutoDI.Build/ProcessAssemblyTask.cs
+++ b/AutoDI.Build/ProcessAssemblyTask.cs
@@ -60,14 +60,20 @@ namespace AutoDI.Build
 
                     ModuleDefinition.Types.Add(GenerateAutoDIClass(mapping, settings, gen, out MethodDefinition initMethod));
 
-                    // AutoLibraryInit overrides AutoInit setting
-                    if (settings.AutoLibraryInit)
+                    switch (settings.InitMode)
                     {
-                        InjectModuleCtorInitCall(initMethod);
-                    }
-                    else if (settings.AutoInit)
-                    {
-                        InjectInitCall(initMethod);
+                        case InitMode.None:
+                            Logger.Debug("Skipping injections of Init method", DebugLogLevel.Verbose);
+                            break;
+                        case InitMode.EntryPoint:
+                            InjectInitCall(initMethod);
+                            break;
+                        case InitMode.ModuleLoad:
+                            InjectModuleCctorInitCall(initMethod);
+                            break;
+                        default:
+                            Logger.Warning($"Unsupported InitMode: {settings.InitMode}");
+                            break;
                     }
                 }
                 else

--- a/AutoDI.Build/Settings.cs
+++ b/AutoDI.Build/Settings.cs
@@ -24,6 +24,9 @@ namespace AutoDI.Build
                                 case nameof(SettingsAttribute.AutoInit):
                                     settings.AutoInit = (bool)property.Argument.Value;
                                     break;
+                                case nameof(SettingsAttribute.AutoLibraryInit):
+                                    settings.AutoLibraryInit = (bool)property.Argument.Value;
+                                    break;
                                 case nameof(SettingsAttribute.Behavior):
                                     settings.Behavior = (Behaviors)property.Argument.Value;
                                     break;
@@ -212,6 +215,15 @@ namespace AutoDI.Build
         /// Automatically initialize AutoDI in assembly entry point (if available)
         /// </summary>
         public bool AutoInit { get; set; } = true;
+
+        /// <summary>
+        /// Automatically initialize AutoDI in assembly's module initializer.
+        /// This means that AutoDI will initialize after loading the module (not necessarily when loading assembly).
+        /// Recommended when you are producing a library that you expect to be consumed
+        /// by others.
+        /// Setting to true will override AutoInit.
+        /// </summary>
+        public bool AutoLibraryInit { get; set; }
 
         /// <summary>
         /// Generate registration calls no the container. Setting to false will negate AutoInit.

--- a/AutoDI.Build/Settings.cs
+++ b/AutoDI.Build/Settings.cs
@@ -21,11 +21,8 @@ namespace AutoDI.Build
                         {
                             switch (property.Name)
                             {
-                                case nameof(SettingsAttribute.AutoInit):
-                                    settings.AutoInit = (bool)property.Argument.Value;
-                                    break;
-                                case nameof(SettingsAttribute.AutoLibraryInit):
-                                    settings.AutoLibraryInit = (bool)property.Argument.Value;
+                                case nameof(SettingsAttribute.InitMode):
+                                    settings.InitMode = (InitMode)property.Argument.Value;
                                     break;
                                 case nameof(SettingsAttribute.Behavior):
                                     settings.Behavior = (Behaviors)property.Argument.Value;
@@ -212,21 +209,12 @@ namespace AutoDI.Build
         public Behaviors Behavior { get; set; } = Behaviors.Default;
 
         /// <summary>
-        /// Automatically initialize AutoDI in assembly entry point (if available)
+        /// Specifies if and when AutoDI initializes during assembly loading.
         /// </summary>
-        public bool AutoInit { get; set; } = true;
+        public InitMode InitMode { get; set; } = InitMode.EntryPoint;
 
         /// <summary>
-        /// Automatically initialize AutoDI in assembly's module initializer.
-        /// This means that AutoDI will initialize after loading the module (not necessarily when loading assembly).
-        /// Recommended when you are producing a library that you expect to be consumed
-        /// by others.
-        /// Setting to true will override AutoInit.
-        /// </summary>
-        public bool AutoLibraryInit { get; set; }
-
-        /// <summary>
-        /// Generate registration calls no the container. Setting to false will negate AutoInit.
+        /// Generate registration calls no the container. Setting to false will negate InitMode.
         /// </summary>
         public bool GenerateRegistrations { get; set; } = true;
 
@@ -248,7 +236,7 @@ namespace AutoDI.Build
 
             sb.AppendLine("AutoDI Settings:");
             sb.AppendLine($"  Behavior(s): {Behavior}");
-            sb.AppendLine($"  AutoInit: {AutoInit}");
+            sb.AppendLine($"  InitMode: {InitMode}");
             sb.AppendLine($"  GenerateRegistrations: {GenerateRegistrations}");
             sb.AppendLine($"  DebugLogLevel: {DebugLogLevel}");
             sb.AppendLine($"  DebugExceptions: {DebugExceptions}");

--- a/AutoDI/InitMode.cs
+++ b/AutoDI/InitMode.cs
@@ -1,0 +1,23 @@
+﻿namespace AutoDI
+{
+    /// <summary>
+    /// Controls when AutoDI is initialized
+    /// </summary>
+    public enum InitMode
+    {
+        /// <summary>
+        /// The container must be initialized manually.
+        /// </summary>
+        None,
+        /// <summary>
+        /// The container will be initialized on your program's entry point.
+        /// Recommended for executable programs.
+        /// </summary>
+        EntryPoint,
+        /// <summary>
+        /// The container will be initialized on assembly module load.
+        /// Recommended for libraries.
+        /// </summary>
+        ModuleLoad
+    }
+}

--- a/AutoDI/SettingsAttribute.cs
+++ b/AutoDI/SettingsAttribute.cs
@@ -6,8 +6,7 @@ namespace AutoDI
     public class SettingsAttribute : Attribute
     {
         public Behaviors Behavior { get; set; }
-        public bool AutoInit { get; set; }
-        public bool AutoLibraryInit { get; set; }
+        public InitMode InitMode { get; set; }
         public bool GenerateRegistrations { get; set; }
         public bool DebugExceptions { get; set; }
         public DebugLogLevel DebugLogLevel { get; set; }

--- a/AutoDI/SettingsAttribute.cs
+++ b/AutoDI/SettingsAttribute.cs
@@ -7,6 +7,7 @@ namespace AutoDI
     {
         public Behaviors Behavior { get; set; }
         public bool AutoInit { get; set; }
+        public bool AutoLibraryInit { get; set; }
         public bool GenerateRegistrations { get; set; }
         public bool DebugExceptions { get; set; }
         public DebugLogLevel DebugLogLevel { get; set; }


### PR DESCRIPTION
This PR adds support for library initialization. It looks for the ModuleDefinition's <Module> type and then creates a static constructor if one isn't already found.

The <Module> .cctor is called when the module is loaded (not necessarily on assembly load).

This is mostly done. I need to write some unit tests for it but it doesn't seem AssemblyGenerator supports weaving in settings so by default AutoInit is true which means AutoLibraryInit is off. Maybe something to look into? Turning it on does mangle a lot of the unit tests because DI.Init tries to get called twice. Hey, at least I know it's working :+1:

I'd also like to discuss the setting name. I tried to come up with something good but it might not be the best while also debating whether to turn the AutoInit from a bool into an enum. Maybe like  
 ```
enum AutoInitMode
{
    None
    EntryPoint
    ModuleLoad
}
```
That would be a breaking change so I decided not to for now.

I've never used AutoDI but it does look neat! Once (and if) this PR is accepted, I'd be happy to update the relevant wiki related to configuration as well!

Related: #154 